### PR TITLE
Add find_target function on project object

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ jobs:
 
 - job: 'Test'
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   strategy:
     matrix:
       Python37:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -351,3 +351,12 @@ def test_pickling(one: xcodeproj.XcodeProject) -> None:
         assert one.objects == two.objects
     finally:
         os.remove(temp)
+
+def test_find_target_by_id(one: xcodeproj.XcodeProject) -> None:
+    """Test that find_target by id works.
+
+    :param one: The project
+    """
+    target = one.project.find_target("DD74C32525AF302A00C4A922")
+    assert target is not None
+    assert isinstance(target, PBXTarget)

--- a/xcodeproj/pbxproject.py
+++ b/xcodeproj/pbxproject.py
@@ -51,6 +51,6 @@ class PBXProject(PBXObject):
         """Get the build configuration list for the project."""
         return cast(XCConfigurationList, self.objects()[self.build_configuration_list_id])
 
-    def find_target(self, id) -> PBXTarget:
+    def find_target(self, id: str) -> PBXTarget:
         """Find target by its id"""
         return cast(PBXTarget, self.objects()[id])

--- a/xcodeproj/pbxproject.py
+++ b/xcodeproj/pbxproject.py
@@ -50,3 +50,7 @@ class PBXProject(PBXObject):
     def build_configuration_list(self) -> XCConfigurationList:
         """Get the build configuration list for the project."""
         return cast(XCConfigurationList, self.objects()[self.build_configuration_list_id])
+
+    def find_target(self, id) -> PBXTarget:
+        """Find target by its id"""
+        return cast(PBXTarget, self.objects()[id])


### PR DESCRIPTION
- Adds `find_target` method on PBXProject object to more easily resolve a PBXTarget object by it's given id