### PR TITLE
Avoid skipping dict objects for weak references

### DIFF
--- a/xcodeproj/__init__.py
+++ b/xcodeproj/__init__.py
@@ -170,8 +170,6 @@ class XcodeProject:
     def _set_weak_refs(self) -> None:
         """Setup the weak references."""
         for obj in self.objects.values():
-            if type(obj) is dict:
-                continue
             obj.objects_ref = weakref.ref(self.objects)
             obj.project_ref = weakref.ref(self)
 


### PR DESCRIPTION
This goes back to #7 and #8. If we want to make sure there's an error if we don't understand something, this should be merged. If we want to allow it to continue and ignore the error we should not. 

I'll let someone else make the call. 😄 