### PR TITLE
Add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 coverage.xml
 dist
 .env
+.venv


### PR DESCRIPTION
Poetry prefers `.venv` so this adds it to the `.gitignore`