### PR TITLE
Bump Python version to 3.10

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -4,10 +4,6 @@ jobs:
       vmImage: "macOS-latest"
     strategy:
       matrix:
-        Python38:
-          python.version: "3.8"
-        Python39:
-          python.version: "3.9"
         Python310:
           python.version: "3.10"
         Python311:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xcodeproj"
-version = "2.0.1"
+version = "2.1.0"
 description = "A utility for interacting with Xcode's xcodeproj bundle format."
 
 license = "MIT"
@@ -17,11 +17,9 @@ homepage = "https://github.com/Microsoft/xcodeproj"
 keywords = ['xcode', 'xcodeproj', 'pbxproj', 'apple']
 
 classifiers = [
-    'Development Status :: 3 - Alpha',
+    'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Topic :: Software Development',
@@ -29,7 +27,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 appdirs = "^1.4.4"
 deserialize = "^2.0.1"
 


### PR DESCRIPTION
This lets us use built in types over the typed types. e.g. `foo: list[int]` rather than `foo: List[int]`