### PR TITLE
Fix paths for PBXReferenceProxy

### DIFF
--- a/tests/collateral/Two.xcodeproj/project.pbxproj
+++ b/tests/collateral/Two.xcodeproj/project.pbxproj
@@ -41,6 +41,13 @@
 			remoteGlobalIDString = DD624D2E25B05EEE0081F68F;
 			remoteInfo = "wat WatchKit Extension";
 		};
+		07231F3E207DA2FF007D566D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = NOTAREALREFERENCE /* SomeOtherProject.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 67A017B82069820500472EB6;
+			remoteInfo = Sometest;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -128,6 +135,7 @@
 		DD62471925AF30980081F68F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				07231F3F207DA2FF007D566D /* SomeTest.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -330,6 +338,16 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		07231F3F207DA2FF007D566D /* SomeTest.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SomeTest.framework;
+			remoteRef = 07231F3E207DA2FF007D566D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		DD624D1B25B05EED0081F68F /* Resources */ = {

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -110,8 +110,8 @@ def test_get_paths(one: xcodeproj.XcodeProject, two: xcodeproj.XcodeProject) -> 
         "Carthage/Build/CocoaLumberjack.xcframework",
         "wat WatchKit Extension/NotificationController.swift",
         "CLJTest/AppDelegate.swift",
-        "$(BUILT_PRODUCTS_DIR)",
-        "$(BUILT_PRODUCTS_DIR)",
+        "wat WatchKit Extension.appex",
+        "CLJTest.app",
         "CLJTest/Base.lproj/LaunchScreen.storyboard",
         "wat WatchKit App/Base.lproj/Interface.storyboard",
         "wat WatchKit Extension/Assets.xcassets",
@@ -120,14 +120,21 @@ def test_get_paths(one: xcodeproj.XcodeProject, two: xcodeproj.XcodeProject) -> 
         "wat WatchKit Extension/PushNotificationPayload.apns",
         "CLJTest/ViewController.swift",
         "wat WatchKit Extension/ExtensionDelegate.swift",
-        "$(BUILT_PRODUCTS_DIR)",
+        "wat.app",
         "CLJTest/Base.lproj/Main.storyboard",
-        "$(BUILT_PRODUCTS_DIR)",
+        "wat WatchKit App.app",
     ]
 
     for index, item in enumerate(one.fetch_type(xcodeproj.PBXFileReference).values()):
         assert item.relative_path() == expected[index]
-        assert item.absolute_path() == os.path.join(COLLATERAL_PATH, expected[index])
+        absolute_path = item.absolute_path()
+
+        assert absolute_path is not None
+
+        if absolute_path.startswith("$(BUILT_PRODUCTS_DIR)/"):
+            assert absolute_path == "$(BUILT_PRODUCTS_DIR)/" + expected[index]
+        else:
+            assert absolute_path == os.path.join(COLLATERAL_PATH, expected[index])
 
     groups = [
         "wat WatchKit App",
@@ -182,8 +189,8 @@ def test_get_paths_prepopulated(one: xcodeproj.XcodeProject, two: xcodeproj.Xcod
         "Carthage/Build/CocoaLumberjack.xcframework",
         "wat WatchKit Extension/NotificationController.swift",
         "CLJTest/AppDelegate.swift",
-        "$(BUILT_PRODUCTS_DIR)",
-        "$(BUILT_PRODUCTS_DIR)",
+        "wat WatchKit Extension.appex",
+        "CLJTest.app",
         "CLJTest/Base.lproj/LaunchScreen.storyboard",
         "wat WatchKit App/Base.lproj/Interface.storyboard",
         "wat WatchKit Extension/Assets.xcassets",
@@ -192,14 +199,21 @@ def test_get_paths_prepopulated(one: xcodeproj.XcodeProject, two: xcodeproj.Xcod
         "wat WatchKit Extension/PushNotificationPayload.apns",
         "CLJTest/ViewController.swift",
         "wat WatchKit Extension/ExtensionDelegate.swift",
-        "$(BUILT_PRODUCTS_DIR)",
+        "wat.app",
         "CLJTest/Base.lproj/Main.storyboard",
-        "$(BUILT_PRODUCTS_DIR)",
+        "wat WatchKit App.app",
     ]
 
     for index, item in enumerate(one.fetch_type(xcodeproj.PBXFileReference).values()):
         assert item.relative_path() == expected[index]
-        assert item.absolute_path() == os.path.join(COLLATERAL_PATH, expected[index])
+        absolute_path = item.absolute_path()
+
+        assert absolute_path is not None
+
+        if absolute_path.startswith("$(BUILT_PRODUCTS_DIR)/"):
+            assert absolute_path == "$(BUILT_PRODUCTS_DIR)/" + expected[index]
+        else:
+            assert absolute_path == os.path.join(COLLATERAL_PATH, expected[index])
 
     groups = [
         "wat WatchKit App",
@@ -230,6 +244,13 @@ def test_get_paths_prepopulated(one: xcodeproj.XcodeProject, two: xcodeproj.Xcod
         else:
             assert version_group.relative_path() is None
             assert version_group.absolute_path() is None
+
+    reference_proxy_expectations = [("BUILT_PRODUCTS_DIR", "SomeTest.framework")]
+
+    for index, proxy in enumerate(two.fetch_type(xcodeproj.PBXReferenceProxy).values()):
+        expected_root, expected_relative = reference_proxy_expectations[index]
+        assert proxy.relative_path() == expected_relative
+        assert proxy.absolute_path() == os.path.join(f"$({expected_root})", expected_relative)
 
 
 def test_get_parents(two: xcodeproj.XcodeProject) -> None:

--- a/xcodeproj/__init__.py
+++ b/xcodeproj/__init__.py
@@ -43,6 +43,7 @@ from .pathobjects import (
     PBXVariantGroup,
     PBXFileReference,
     XCVersionGroup,
+    PBXReferenceProxy,
 )
 from .pbxproject import PBXProject
 from .other import PBXTargetDependency, PBXContainerItemProxy
@@ -233,7 +234,7 @@ class XcodeProject:
         if self._is_populated:
             return
 
-        non_set = []
+        non_set: list[PBXPathObject] = []
 
         root_group = self.objects[self.project.main_group_id]
         self._populate(root_group, None, non_set)

--- a/xcodeproj/other.py
+++ b/xcodeproj/other.py
@@ -38,21 +38,6 @@ class PBXContainerItemProxy(PBXObject):
 
 
 @deserialize.auto_snake()
-@deserialize.downcast_identifier(PBXObject, "PBXReferenceProxy")
-class PBXReferenceProxy(PBXObject):
-    """Represents a PBXReferenceProxy.
-
-    It's not clear what this one is. As far as I can tell, it references
-    something in another project in the same workspace.
-    """
-
-    file_type: str
-    path: str
-    remote_ref: str
-    source_tree: str
-
-
-@deserialize.auto_snake()
 class ProjectReference:
     """A reference to another project."""
 


### PR DESCRIPTION
This is a path object, unlike what the previous versions of this library implied. Fixing this also pointed out a mistake in how we handle paths with variables in them. That has also been fixed.