### PR TITLE
Support Xcode 16 buildable folders (synchronized root groups)

### DIFF
--- a/tests/collateral/Synchronized/Sources/Probe.swift
+++ b/tests/collateral/Synchronized/Sources/Probe.swift
@@ -1,0 +1,1 @@
+public enum Probe { public static let value = 1 }

--- a/tests/collateral/Synchronized/Synchronized.xcodeproj/project.pbxproj
+++ b/tests/collateral/Synchronized/Synchronized.xcodeproj/project.pbxproj
@@ -1,0 +1,294 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		627B9CE91BDA0D612E7FD1B6 /* Synchronized.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Synchronized.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		133F42F381B2B5DDEC115EEF /* Sources */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Sources;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXGroup section */
+		1123A7B3E9E3C07374EA7EE0 = {
+			isa = PBXGroup;
+			children = (
+				133F42F381B2B5DDEC115EEF /* Sources */,
+				66BA250FE5C414863921768C /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		66BA250FE5C414863921768C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				627B9CE91BDA0D612E7FD1B6 /* Synchronized.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B02CD864C5DF1A379D1FECBE /* Synchronized */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C84B02E040EACA386E12BE52 /* Build configuration list for PBXNativeTarget "Synchronized" */;
+			buildPhases = (
+				4742ABDE0C5C114C5C6349B5 /* Sources */,
+				16DB6A56E1F4286326A8358E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				133F42F381B2B5DDEC115EEF /* Sources */,
+			);
+			name = Synchronized;
+			packageProductDependencies = (
+			);
+			productName = Synchronized;
+			productReference = 627B9CE91BDA0D612E7FD1B6 /* Synchronized.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		45B925CF515BF9324CB866F9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+			};
+			buildConfigurationList = 2E3AE5B9D77FDA9AC138123F /* Build configuration list for PBXProject "Synchronized" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 1123A7B3E9E3C07374EA7EE0;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 66BA250FE5C414863921768C /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B02CD864C5DF1A379D1FECBE /* Synchronized */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		16DB6A56E1F4286326A8358E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4742ABDE0C5C114C5C6349B5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		27192C5FF6E883E27B826F97 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		491BF2F17D3D05F1CCF17ACA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		5922255422447D71F087ECEB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		B8A7475B4F20FB6D8DD1D4A9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2E3AE5B9D77FDA9AC138123F /* Build configuration list for PBXProject "Synchronized" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				27192C5FF6E883E27B826F97 /* Debug */,
+				5922255422447D71F087ECEB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C84B02E040EACA386E12BE52 /* Build configuration list for PBXNativeTarget "Synchronized" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				491BF2F17D3D05F1CCF17ACA /* Debug */,
+				B8A7475B4F20FB6D8DD1D4A9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 45B925CF515BF9324CB866F9 /* Project object */;
+}

--- a/tests/collateral/Synchronized/project.yml
+++ b/tests/collateral/Synchronized/project.yml
@@ -1,0 +1,15 @@
+# Minimal Xcode 16 buildable-folder project used as a deserialization fixture.
+# Generated with: xcodegen generate (XcodeGen 2.45+, projectFormat xcode16_0).
+# The empty `explicitFileTypes`/`explicitFolders` that XcodeGen emits on the
+# synchronized group are trimmed afterwards to mirror the Xcode-native shape
+# (Xcode omits them when empty), exercising the optional-field defaults.
+name: Synchronized
+options:
+  projectFormat: xcode16_0
+targets:
+  Synchronized:
+    type: framework
+    platform: iOS
+    sources:
+      - path: Sources
+        type: syncedFolder

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -38,6 +38,16 @@ def two() -> xcodeproj.XcodeProject:
     return xcodeproj.XcodeProject(two_path)
 
 
+@pytest.fixture(scope="session")
+def synchronized() -> xcodeproj.XcodeProject:
+    """Load an Xcode 16 buildable-folder project.
+
+    :returns: The project
+    """
+    path = os.path.join(COLLATERAL_PATH, "Synchronized", "Synchronized.xcodeproj")
+    return xcodeproj.XcodeProject(path)
+
+
 def test_base_references(one: xcodeproj.XcodeProject) -> None:
     """Test that references work
 
@@ -390,3 +400,43 @@ def test_find_target_by_id(one: xcodeproj.XcodeProject) -> None:
     target = one.project.find_target("DD74C32525AF302A00C4A922")
     assert target is not None
     assert isinstance(target, xcodeproj.PBXTarget)
+
+
+def test_synchronized_root_group_optional_fields(synchronized: xcodeproj.XcodeProject) -> None:
+    """Xcode omits empty exceptions/explicitFileTypes/explicitFolders on a
+    synchronized root group, so they should default to empty containers.
+
+    :param synchronized: The Xcode 16 buildable-folder project
+    """
+    groups = list(synchronized.fetch_type(xcodeproj.PBXFileSystemSynchronizedRootGroup).values())
+    assert len(groups) == 1
+
+    group = groups[0]
+    assert group.path == "Sources"
+    assert group.exception_ids == []
+    assert group.explicit_file_types == {}
+    assert group.explicit_folders == []
+
+
+def test_synchronized_project_omits_compatibility_version(
+    synchronized: xcodeproj.XcodeProject,
+) -> None:
+    """The Xcode 16 (objectVersion 77) format omits compatibilityVersion.
+
+    :param synchronized: The Xcode 16 buildable-folder project
+    """
+    assert synchronized.project.compatibility_version is None
+
+
+def test_target_file_system_synchronized_groups(
+    synchronized: xcodeproj.XcodeProject,
+) -> None:
+    """A target references its synchronized root groups via fileSystemSynchronizedGroups.
+
+    :param synchronized: The Xcode 16 buildable-folder project
+    """
+    group = list(synchronized.fetch_type(xcodeproj.PBXFileSystemSynchronizedRootGroup).values())[0]
+
+    targets = synchronized.project.targets
+    assert len(targets) == 1
+    assert targets[0].file_system_synchronized_group_ids == [group.object_key]

--- a/xcodeproj/pathobjects.py
+++ b/xcodeproj/pathobjects.py
@@ -295,6 +295,9 @@ class PBXReferenceProxy(PBXPathObject):
 @deserialize.key("explicit_file_types", "explicitFileTypes")
 @deserialize.key("explicit_folders", "explicitFolders")
 @deserialize.key("exception_ids", "exceptions")
+@deserialize.default("exception_ids", [])
+@deserialize.default("explicit_file_types", {})
+@deserialize.default("explicit_folders", [])
 @deserialize.downcast_identifier(PBXObject, "PBXFileSystemSynchronizedRootGroup")
 class PBXFileSystemSynchronizedRootGroup(PBXPathObject):
     """Represents a PBXFileSystemSynchronizedRootGroup.

--- a/xcodeproj/pbxproject.py
+++ b/xcodeproj/pbxproject.py
@@ -25,7 +25,7 @@ class PBXProject(PBXObject):
 
     attributes: dict[str, Any]
     build_configuration_list_id: str
-    compatibility_version: str
+    compatibility_version: str | None
     development_region: str
     has_scanned_for_encodings: bool
     known_regions: list[str]

--- a/xcodeproj/targets.py
+++ b/xcodeproj/targets.py
@@ -37,6 +37,7 @@ class PBXProductType(enum.Enum):
 @deserialize.key("build_phases_ids", "buildPhases")
 @deserialize.key("build_configuration_list_id", "buildConfigurationList")
 @deserialize.key("dependency_ids", "dependencies")
+@deserialize.key("file_system_synchronized_group_ids", "fileSystemSynchronizedGroups")
 @deserialize.auto_snake()
 class PBXTarget(PBXObject):
     """Represents a PBXTarget."""
@@ -44,6 +45,7 @@ class PBXTarget(PBXObject):
     build_configuration_list_id: str
     build_phases_ids: list[str]
     dependency_ids: list[str]
+    file_system_synchronized_group_ids: list[str] | None
     name: str
     product_name: str | None
 


### PR DESCRIPTION
Parsing a project that uses Xcode 16 buildable folders currently fails to deserialize. Three fields produced by that format are not tolerated:

- PBXFileSystemSynchronizedRootGroup omits `exceptions`, `explicitFileTypes` and `explicitFolders` when empty (Xcode omits them; CocoaPods' Xcodeproj strips them on rewrite), but they were required. Default them to empty containers.
- PBXProject omits `compatibilityVersion` in the objectVersion 77 format (replaced by `preferredProjectObjectVersion`). Make `compatibility_version` optional.
- Targets reference their synchronized groups via `fileSystemSynchronizedGroups`, which was unhandled. Add `file_system_synchronized_group_ids`.

Add a `Synchronized` fixture (XcodeGen spec + the Xcode-emitted project) and tests covering each case.